### PR TITLE
Support for BookBeat, no metadata!

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ CLI tool for downloading audiobooks from online sources.
 ## Supported Services
 audiobook-dl currently supports downloading from the following sources:
 - [audiobooks.com](https://audiobooks.com)
+- [BookBeat](https://www.bookbeat.com/)
 - [Chirp](https://www.chirpbooks.com/)
 - [eReolen (Danish Library)](https://ereolen.dk)
 - [Librivox](https://librivox.org)

--- a/audiobookdl/output/metadata.py
+++ b/audiobookdl/output/metadata.py
@@ -3,7 +3,7 @@ import os
 from mutagen import File as MutagenFile
 from mutagen.easyid3 import EasyID3
 from mutagen.mp3 import MP3
-from mutagen.id3 import ID3, APIC, CHAP, TIT2, CTOC, CTOCFlags
+from mutagen.id3 import ID3, APIC, CHAP, TIT2, CTOC, CTOCFlags, ID3NoHeaderError
 from typing import Dict
 
 # List of file formats that use ID3 metadata
@@ -48,7 +48,10 @@ def add_metadata(filepath: str, metadata: Dict[str, str]):
 def embed_cover(filepath: str, image: bytes, extension: str):
     """Embeds an image into the given audio file"""
     mimetype = EXTENSION_TO_MIMETYPE[extension]
-    audio = ID3(filepath)
+    try:
+        audio = ID3(filepath)
+    except ID3NoHeaderError:
+        return
     audio.add(APIC(type=0, data=image, mime=mimetype))
     audio.save()
 
@@ -64,8 +67,10 @@ def add_chapter(audio: ID3, start: int, end: int, title: str, index: int):
 
 def add_chapters(filepath, chapters):
     """Adds chapters to the given audio file"""
-    audio = ID3(filepath)
-    # Adding chapters
+    try:
+        audio = ID3(filepath)
+    except ID3NoHeaderError:
+        return    # Adding chapters
     for i in range(len(chapters)-1):
         add_chapter(
                 audio,

--- a/audiobookdl/sources/__init__.py
+++ b/audiobookdl/sources/__init__.py
@@ -1,6 +1,7 @@
 from .source import Source
 
 from .audiobooksdotcom import AudiobooksdotcomSource
+from .bookbeat import BookBeatSource
 from .chirp import ChirpSource
 from .ereolen import EreolenSource
 from .librivox import LibrivoxSource
@@ -27,6 +28,7 @@ def get_source_classes():
     """Returns a list of all available sources"""
     return [
         AudiobooksdotcomSource,
+        BookBeatSource,
         ChirpSource,
         EreolenSource,
         LibrivoxSource,

--- a/audiobookdl/sources/bookbeat.py
+++ b/audiobookdl/sources/bookbeat.py
@@ -1,0 +1,133 @@
+from .source import Source
+from audiobookdl import AudiobookFile
+from typing import Any
+import uuid
+from audiobookdl.exceptions import UserNotAuthorized, MissingBookAccess
+import base64
+import re
+
+
+def get_device_id() -> str:
+    return (
+        str(uuid.uuid3(uuid.NAMESPACE_DNS, "audiobook-dl"))
+        + " "
+        + base64.b64encode(b"Personal Computer").decode()
+    )
+
+
+class BookBeatSource(Source):
+    match = [
+        r"https?://(www.)?bookbeat.+",
+    ]
+    names = ["BookBeat"]
+    _authentication_methods = [
+        "login",
+    ]
+
+    saved_books: dict
+    book_info: dict
+
+    def _login(self, username: str, password: str):
+        headers = {
+            "accept": "application/hal+json",
+            "bb-client": "BookBeatApp",
+            "bb-device": get_device_id(),
+        }
+        self._session.headers = headers
+
+        j = {"username": username, "password": password}
+
+        r = self._session.post("https://api.bookbeat.com/api/login", json=j)
+        if not r.status_code == 200:
+            raise UserNotAuthorized
+
+        tokens = r.json()
+        self._session.headers.update({"authorization": "Bearer " + tokens["token"]})
+
+        r = self._session.get(
+            "https://api.bookbeat.com/api/my/books/saved?offset=0&limit=100"
+        )
+        if not r.status_code == 200:
+            raise MissingBookAccess
+        self.saved_books = r.json()
+
+    def get_title(self) -> str:
+        return self.book_info["metadata"]["title"]
+
+    def get_files(self) -> list[AudiobookFile]:
+        r = self._session.get(
+            "https://api.bookbeat.com/api/downloadinfo/" + str(self.book_info["bookid"])
+        )
+        if not r.status_code == 200:
+            raise MissingBookAccess
+        dl_info = r.json()
+
+        license_url = ""
+
+        if "_embedded" in dl_info:
+            if "downloads" in dl_info["_embedded"]:
+                for dl in dl_info["_embedded"]["downloads"]:
+                    if dl["format"] == "audioBook":
+                        license_url = dl["_links"]["license"]["href"]
+                        break
+
+        if license_url:
+            r = self._session.get(license_url)
+            if not r.status_code == 200:
+                raise MissingBookAccess
+            lic = r.json()
+            self.book_info["license"] = lic
+            if "_links" in lic:
+                return [
+                    AudiobookFile(
+                        url=lic["_links"]["download"]["href"],
+                        headers=self._session.headers,
+                        ext="mp4",
+                    )
+                ]
+
+            raise MissingBookAccess
+
+    def get_metadata(self) -> dict[str, Any]:
+        try:
+            metadata = {
+                "authors": [
+                    a
+                    for a in self.book_info["metadata"]["contributors"]
+                    if "author" in a["role"]
+                ],
+                "narrators": [
+                    n
+                    for n in self.book_info["metadata"]["contributors"]
+                    if "narrator" in n["role"]
+                ],
+            }
+            return metadata
+        except:
+            return {}
+
+    def get_chapters(self) -> list[tuple[int, str]] | None:
+        chapter_number = 1
+        chapters = []
+        for track in self.book_info["license"]["tracks"]:
+            chapters.append((track["start"], f"Chapter {chapter_number}"))
+            chapter_number += 1
+        return chapters
+
+    def get_cover(self) -> bytes | None:
+        return self.get(self.book_info["metadata"]["cover"])
+
+    def before(self):
+        book_id_re = r"(\d+)$"
+        wanted_id_match = re.search(book_id_re, self.url)
+        if not wanted_id_match:
+            raise ValueError(f"Couldn't get bookid from url {self.url}")
+        wanted_id = wanted_id_match.group(1)
+        for book in self.saved_books["_embedded"]["savedBooks"]:
+            if str(book["bookid"]) == wanted_id:
+                self.book_info = book
+                self.book_info["metadata"] = self._session.get(
+                    self.book_info["_links"]["book"]["href"]
+                ).json()
+                return
+        raise MissingBookAccess

--- a/audiobookdl/sources/bookbeat.py
+++ b/audiobookdl/sources/bookbeat.py
@@ -90,15 +90,27 @@ class BookBeatSource(Source):
 
     def get_metadata(self) -> dict[str, Any]:
         try:
+            contributors = next(
+                iter(
+                    [
+                        e["contributors"]
+                        for e in self.book_info["metadata"]["editions"]
+                        if e["format"] == "audioBook"
+                    ]
+                ),
+                None,
+            )
+            if not contributors:
+                return {}
             metadata = {
                 "authors": [
-                    a
-                    for a in self.book_info["metadata"]["contributors"]
+                    f"{a['firstname']} {a['lastname']}"
+                    for a in contributors
                     if "author" in a["role"]
                 ],
                 "narrators": [
-                    n
-                    for n in self.book_info["metadata"]["contributors"]
+                    f"{n['firstname']} {n['lastname']}"
+                    for n in contributors
                     if "narrator" in n["role"]
                 ],
             }
@@ -112,6 +124,7 @@ class BookBeatSource(Source):
         for track in self.book_info["license"]["tracks"]:
             chapters.append((track["start"], f"Chapter {chapter_number}"))
             chapter_number += 1
+
         return chapters
 
     def get_cover(self) -> bytes | None:

--- a/supported_sites.md
+++ b/supported_sites.md
@@ -1,14 +1,14 @@
 # Supported Sites
 
-| Site             | Cookies | Username/Password | Notes                                                                                              |
-|:-----------------|:-------:|:-----------------:|:---------------------------------------------------------------------------------------------------|
-| audiobooks.com   |    ✓    |         ✗         |                                                                                                    |
-| BookBeat         |    ✗    |         ✓         | Books must be saves on your account <br> Not tested with multi-user account <br> No metadata (yet) |
-| Chirp            |    ✓    |         ✗         |                                                                                                    |
-| eReolen          |    ✓    |         ✓         | Requires library for login                                                                         |
-| Librivox         |    ✗    |         ✗         | Authentication not required                                                                        |
-| Nextory          |    ✗    |         ✓         | Books must be in "Your Library" <br/>Only single (first) account supported                         |
-| Overdrive        |    ✓    |         ✗         |                                                                                                    |
-| Scribd           |    ✓    |         ✗         |                                                                                                    |
-| Storytel         |    ✗    |         ✓         | Books have to be in your bookshelf                                                                 |
-| YourCloudLibrary |    ✓    |         ✓         |                                                                                                    |
+| Site             | Cookies | Username/Password | Notes                                                                                          |
+|:-----------------|:-------:|:-----------------:|:-----------------------------------------------------------------------------------------------|
+| audiobooks.com   |    ✓    |         ✗         |                                                                                                |
+| BookBeat         |    ✗    |         ✓         | Books must be saved to My Books <br> Not tested with multi-user account <br> No metadata (yet) |
+| Chirp            |    ✓    |         ✗         |                                                                                                |
+| eReolen          |    ✓    |         ✓         | Requires library for login                                                                     |
+| Librivox         |    ✗    |         ✗         | Authentication not required                                                                    |
+| Nextory          |    ✗    |         ✓         | Books must be in "Your Library" <br/>Only single (first) account supported                     |
+| Overdrive        |    ✓    |         ✗         |                                                                                                |
+| Scribd           |    ✓    |         ✗         |                                                                                                |
+| Storytel         |    ✗    |         ✓         | Books have to be in your bookshelf                                                             |
+| YourCloudLibrary |    ✓    |         ✓         |                                                                                                |

--- a/supported_sites.md
+++ b/supported_sites.md
@@ -1,13 +1,14 @@
 # Supported Sites
 
-| Site             | Cookies | Username/Password | Notes                                                                      |
-|:-----------------|:-------:|:-----------------:|:---------------------------------------------------------------------------|
-| audiobooks.com   |    ✓    |         ✗         |                                                                            |
-| Chirp            |    ✓    |         ✗         |                                                                            |
-| eReolen          |    ✓    |         ✓         | Requires library for login                                                 |
-| Librivox         |    ✗    |         ✗         | Authentication not required                                                |
-| Nextory          |    ✗    |         ✓         | Books must be in "Your Library" <br/>Only single (first) account supported |
-| Overdrive        |    ✓    |         ✗         |                                                                            |
-| Scribd           |    ✓    |         ✗         |                                                                            |
-| Storytel         |    ✗    |         ✓         | Books have to be in your bookshelf                                         |
-| YourCloudLibrary |    ✓    |         ✓         |                                                                            |
+| Site             | Cookies | Username/Password | Notes                                                                                              |
+|:-----------------|:-------:|:-----------------:|:---------------------------------------------------------------------------------------------------|
+| audiobooks.com   |    ✓    |         ✗         |                                                                                                    |
+| BookBeat         |    ✗    |         ✓         | Books must be saves on your account <br> Not tested with multi-user account <br> No metadata (yet) |
+| Chirp            |    ✓    |         ✗         |                                                                                                    |
+| eReolen          |    ✓    |         ✓         | Requires library for login                                                                         |
+| Librivox         |    ✗    |         ✗         | Authentication not required                                                                        |
+| Nextory          |    ✗    |         ✓         | Books must be in "Your Library" <br/>Only single (first) account supported                         |
+| Overdrive        |    ✓    |         ✗         |                                                                                                    |
+| Scribd           |    ✓    |         ✗         |                                                                                                    |
+| Storytel         |    ✗    |         ✓         | Books have to be in your bookshelf                                                                 |
+| YourCloudLibrary |    ✓    |         ✓         |                                                                                                    |

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -2,6 +2,7 @@ from audiobookdl.sources import find_compatible_source
 
 TEST_DATA = {
     "https://www.audiobooks.com/book/stream/413879": "Audiobooksdotcom",
+    "https://www.bookbeat.no/bok/somethingsomething-999999": "BookBeat",
     "https://ereolen.dk/ting/object/870970-basis%3A53978223": "Ereolen",
     "https://www.chirpbooks.com/player/11435746": "Chirp",
     "https://librivox.org/library-of-the-worlds-best-literature-ancient-and-modern-volume-3-by-various/": "Librivox",


### PR DESCRIPTION
Added support for BookBeat, #22

BookBeat's audiobooks are mp4/aac files. I couldn't get this to work with the way we currently embed metadata. Maybe we need to use mutagen.MP4? Because of this it's hard to test if chapters etc are correctly parsed. For now I've added try/catches in metadata.py so that it won't crash when trying to write the id3 to mp4 files.

For this to work the user must have saved the audiobook to "My Books".

The links look like this:
https://www.bookbeat.no/bok/666836
or this:
https://www.bookbeat.no/bok/karsten-og-petra-hilser-pa-kongen-666836