### PR TITLE
add new metadata fields

### DIFF
--- a/audiobookdl/output/metadata/id3.py
+++ b/audiobookdl/output/metadata/id3.py
@@ -1,20 +1,46 @@
 import re
 import os
+from datetime import date
 from audiobookdl import logging, Chapter, AudiobookMetadata, Cover
 
 from mutagen import File as MutagenFile
-from mutagen.easyid3 import EasyID3
+from mutagen.easyid3 import EasyID3, EasyID3KeyError
 from mutagen.mp3 import MP3
-from mutagen.id3 import ID3, APIC, CHAP, TIT2, CTOC, CTOCFlags, ID3NoHeaderError
+from mutagen.id3 import ID3, APIC, CHAP, TIT2, CTOC, CTOCFlags, WCOM, ID3NoHeaderError
 
 from typing import Sequence
 
+EasyID3.RegisterTextKey("comment", "COMM")
+EasyID3.RegisterTextKey("year", "TYER")
+EasyID3.RegisterTextKey("originalreleaseyear", "TORY")
+EasyID3.RegisterTXXXKey("isbn", "ISBN")
+
+def commercialurl_get(id3, key):
+    urls = [frame.url for frame in id3.getall("WCOM")]
+    if urls:
+        return urls
+    else:
+        raise EasyID3KeyError(key)
+
+def commercialurl_set(id3, key, value):
+    id3.delall("WCOM")
+    for v in value:
+        id3.add(WCOM(url=v))
+
+def commercialurl_delete(id3, key):
+    id3.delall("WCOM")
+
+EasyID3.RegisterKey("commercialurl", commercialurl_get, commercialurl_set, commercialurl_delete)
+
 # Conversion table between metadata names and ID3 tags
 ID3_CONVERT = {
-    "author": "artist",
+    "authors": "artist",
     "series": "album",
     "title": "title",
-    "narrator": "performer",
+    "publisher": "organization", # TPUB
+    "description": "comment", # COMM
+    "genres": "genre", # TCON
+    "scrape_url": "commercialurl", # WCOM
 }
 
 # List of file formats that use ID3 metadata
@@ -36,12 +62,23 @@ def add_id3_metadata(filepath: str, metadata: AudiobookMetadata):
     """Add ID3 metadata tags to the given audio file"""
     audio = MP3(filepath, ID3=EasyID3)
     # Adding tags
-    for key, value in metadata.all_properties(allow_duplicate_keys=False):
-        if key in ID3_CONVERT:
+    for key, value in metadata.all_properties(allow_duplicate_keys=None):
+        if key == "release_date":
+            value: date
+            audio["originaldate"] = value.strftime("%Y-%m-%d")
+            audio["year"] = audio["originaldate"]
+        elif key == "language":
+            audio["language"] = value.alpha_3
+        elif key == "narrators":
+            audio["composer"] = value
+            audio["performer"] = value
+        elif key == "series_order":
+            audio["tracknumber"] = str(value)
+        elif key in ID3_CONVERT:
             audio[ID3_CONVERT[key]] = value
         elif key in EasyID3.valid_keys.keys():
             audio[key] = value
-    audio.save(v2_version=3)
+    audio.save(v2_version=4)
 
 
 def embed_id3_cover(filepath: str, cover: Cover):

--- a/audiobookdl/output/metadata/mp4.py
+++ b/audiobookdl/output/metadata/mp4.py
@@ -1,15 +1,19 @@
 import re
+from datetime import date
 
 from audiobookdl import logging, AudiobookMetadata, Cover
-from mutagen.easymp4 import EasyMP4
+from mutagen.easymp4 import EasyMP4, EasyMP4Tags
 from mutagen.mp4 import MP4, MP4Cover, Chapter as MP4Chapter, MP4Chapters
 
 MP4_EXTENSIONS = ["mp4","m4a","m4p","m4b","m4r","m4v"]
 
 MP4_CONVERT = {
-    "author": "artist",
+    "authors": "artist",
+    "narrators": "narrator",
+    "publishers": "publisher",
     "series": "album",
     "title": "title",
+    "genres": "genre",
 }
 
 MP4_COVER_FORMATS = {
@@ -17,6 +21,12 @@ MP4_COVER_FORMATS = {
     "jpeg": MP4Cover.FORMAT_JPEG,
     "png": MP4Cover.FORMAT_PNG,
 }
+
+EasyMP4Tags.RegisterTextKey("year", 'yrrc')
+EasyMP4Tags.RegisterTextKey("narrator", '\xa9nrt')
+EasyMP4Tags.RegisterTextKey("publisher", '\xa9pub')
+EasyMP4Tags.RegisterTextKey("track", '\xa9trk')
+EasyMP4Tags.RegisterFreeformKey("scrape_url", "URL")
 
 def is_mp4_file(filepath: str) -> bool:
     """Returns true if `filepath` points to an id3 file"""
@@ -27,9 +37,18 @@ def is_mp4_file(filepath: str) -> bool:
 def add_mp4_metadata(filepath: str, metadata: AudiobookMetadata):
     """Add mp4 metadata tags to the given audio file"""
     audio = EasyMP4(filepath)
-    for key, value in metadata.all_properties(allow_duplicate_keys=True):
+    for key, value in metadata.all_properties(allow_duplicate_keys=None):
         # System defined metadata tags
-        if key in MP4_CONVERT:
+        if key == "release_date":
+            value: date
+            audio["date"] = value.strftime("%Y-%m-%d")
+            audio["year"] = str(value.year)
+        elif key == "language":
+            audio.tags.RegisterFreeformKey(key, key.capitalize())
+            audio["language"] = value.alpha_3
+        elif key == "series_order":
+            audio["track"] = str(value)
+        elif key in MP4_CONVERT:
             audio[MP4_CONVERT[key]] = value
         elif key in audio.Get.keys():
             audio[key] = value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "requests",
     "rich",
     "tomli",
+    "pycountry",
 ]
 dynamic = ["version"]
 

--- a/shell.nix
+++ b/shell.nix
@@ -16,6 +16,7 @@ mkShell {
       appdirs
       tomli
       attrs
+      pycountry
 
       # Test
       pytest


### PR DESCRIPTION
- Add publisher, description, genres and scrape_url fields
- language metadata datatype is changed to pycountry.db.Language (adds pycontry as dependency), no source was using language, so it shouldn't be a problem
- ID3 version is changed from 2.3 to 2.4 (proper support for multiple values per field)
- Multi value fields are passed as list to mutagen (mutagen will generate correct multi value ID3/mp4 metadata headers)