### PR TITLE
Fix Podimo authentication + added proper user-agent for GraphQL requests

### DIFF
--- a/audiobookdl/assets/sources/podimo/login.graphql
+++ b/audiobookdl/assets/sources/podimo/login.graphql
@@ -1,1 +1,7 @@
-query LoginResultsQuery($email: String!, $password: String!) {  tokenWithCredentials(email: $email, password: $password, source: WEB) {    ...AuthTokensFragment    __typename  }}fragment AuthTokensFragment on AccessToken {  accessToken: token  refreshToken  __typename}
+query web_logInUser($email: String!, $password: String!) {
+ tokenWithCredentials(email: $email, password: $password) {
+  token
+  isNewUser
+  __typename
+  }
+}

--- a/audiobookdl/sources/podimo.py
+++ b/audiobookdl/sources/podimo.py
@@ -22,14 +22,14 @@ class PodimoSource(Source[dict]):
 
     def _login(self, url: str, username: str, password: str) -> None:
         response = self.graphql_request(
-            operation_name = "LoginResultsQuery",
+            operation_name = "web_logInUser",
             query = "login",
             variables = {
                 "email": username,
                 "password": password
             }
         )
-        authorization_token = response.json()["data"]["tokenWithCredentials"]["accessToken"]
+        authorization_token = response.json()["data"]["tokenWithCredentials"]["token"]
         logging.debug(f"{authorization_token=}")
         self._session.headers.update({"authorization": authorization_token})
 
@@ -45,7 +45,7 @@ class PodimoSource(Source[dict]):
         """
         return self._session.post(
             "https://podimo.com/graphql",
-            params = { "queryName": operation_name },
+            headers = {"User-Agent": "JS GraphQL"},
             json = {
                 "operationName": operation_name,
                 "query": read_asset_file(f"assets/sources/podimo/{query}.graphql"),


### PR DESCRIPTION
Hey!

I wanted to download some stuff from Podimo for my sister,
But authentication is broken by some small changes in API on Podimo's side.

So i decided to fix it and it worked out, and now i want to commit the changes back so other people can get it working again too.

For `login.graphql` i stayed faithful to what the webbrowser does and added newlines and verified it's the same.
I know this is different from the other graphql files, i would have changed all other graphql files if i was more confident.

This is my first real pull request.