### PR TITLE
Fix to keep existing metadata to audio file when adding chapters

### DIFF
--- a/audiobookdl/output/metadata/ffmpeg.py
+++ b/audiobookdl/output/metadata/ffmpeg.py
@@ -35,11 +35,18 @@ def add_chapters_ffmpeg(filepath: str, chapters: Sequence[Chapter]):
         with open(TMP_CHAPTER_FILE, "w") as f:
             f.write(create_tmp_chapter_file(filepath, chapters))
         subprocess.run(
-            ["ffmpeg", "-y", "-i", filepath, "-i", TMP_CHAPTER_FILE,
-                "-map_metadata", "1", "-c", "copy", TMP_MEDIA_FILE],
+            ["ffmpeg", "-y", 
+             "-i", filepath, 
+             "-i", TMP_CHAPTER_FILE,
+             "-map_chapters", "1",
+             "-c", "copy",
+             "-map", "0",
+             "-metadata:s:a:0", "title=",
+             TMP_MEDIA_FILE],
             capture_output = not logging.ffmpeg_output
         )
         os.remove(filepath)
         os.rename(TMP_MEDIA_FILE, filepath)
     finally:
         os.remove(TMP_CHAPTER_FILE)
+        

--- a/audiobookdl/sources/storytel.py
+++ b/audiobookdl/sources/storytel.py
@@ -460,9 +460,9 @@ class StorytelSource(Source):
         if "description" in book_details:
             metadata.description = book_details["description"]
         if "language" in book_details:
-            if "name" in book_details["language"]:
+            if book_details["language"]:
                 metadata.language = pycountry.languages.get(
-                    name=book_details["language"]["name"]
+                    alpha_2=book_details["language"]
                 )
         if "category" in book_details:
             if "name" in book_details["category"]:


### PR DESCRIPTION
This fixes an issue when adding chapters to an mp4 file the existing metadata will not be mapped to the output file.