### PR TITLE
Nextory: Added new required header X-Os-Info

### DIFF
--- a/audiobookdl/sources/nextory.py
+++ b/audiobookdl/sources/nextory.py
@@ -48,6 +48,7 @@ class NextorySource(Source):
                 "X-Locale": self.LOCALE,
                 "X-Model": "Personal Computer",
                 "X-Device-Id": device_id,
+		"X-Os-Info": "Android"
             }
         )
         # Login for account


### PR DESCRIPTION
Fixes problem with nextory as described in issue #89
Added new required header X-Os-Info set to dummy value "Android".
