### PR TITLE
Fix Nextory combine/chapter issues for large segmented books

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ audiobook-dl uses Netscape cookie files for authentication in most cases. I use
 from the browser.
 
 Cookies can be placed in current dir as `cookies.txt` or be given with the
-`--cookie` argument.
+`--cookies` argument.
 
 ### Login
 [Some sources](./supported_sites.md) support authentication through login with
@@ -76,21 +76,29 @@ information page**
 
 ## Arguments
 
-| Argument          | Value                                                             |
-|-------------------|-------------------------------------------------------------------|
-| url               | The url of the page where you listen to the audiobook             |
-| -c/--cookie       | Path to a Netscape cookie file                                    |
-| --combine         | Combine all output files into a single file (requires ffmpeg)     |
-| --cover           | Only download cover                                               |
-| -d/--debug        | Print debug information                                           |
-| -o/--output       | Output location                                                   |
-| --remove-chars    | List of characters that will be removed from output path          |
-| --no-chapters     | Don't include chapters in output file                             |
-| --output-format   | Output file format                                                |
-| --verbose-ffmpeg | Show ffmpeg output in terminal                                    |
-| --username        | Username to source (Required when using login)                    |
-| --password        | Password to source (Required when using login)                    |
-| --library         | Specific library on service (Sometimes required when using login) |
+| Argument                 | Value | Example |
+|--------------------------|-------|---------|
+| `urls`                   | One or more urls to download from | `audiobook-dl <url1> <url2>` |
+| `-v`, `--version`        | Print version and exit | `audiobook-dl --version` |
+| `-c`, `--cookies`        | Path to a Netscape cookie file | `audiobook-dl -c cookies.txt <url>` |
+| `--combine`              | Combine all output files into a single file (requires ffmpeg) | `audiobook-dl --combine <url>` |
+| `-o`, `--output`         | Output location/template (default: `{title}`) | `audiobook-dl -o "C:\Audiobooks\{title}" <url>` |
+| `--remove-chars`         | List of characters that will be removed from output path | `audiobook-dl --remove-chars "[]()" <url>` |
+| `-d`, `--debug`          | Print debug information | `audiobook-dl --debug <url>` |
+| `-q`, `--quiet`          | Quiet mode | `audiobook-dl --quiet <url>` |
+| `--print-output`         | Print the output path instead of downloading | `audiobook-dl --print-output <url>` |
+| `--cover`                | Download only cover | `audiobook-dl --cover <url>` |
+| `--no-chapters`          | Don't include chapters in output file | `audiobook-dl --no-chapters <url>` |
+| `-f`, `--output-format`  | Output file format | `audiobook-dl -f mp3 <url>` |
+| `--verbose-ffmpeg`       | Show ffmpeg output in terminal | `audiobook-dl --verbose-ffmpeg --combine <url>` |
+| `--input-file`           | File with one url per line | `audiobook-dl --input-file urls.txt` |
+| `--username`             | Username to source (required when using login) | `audiobook-dl --username "me@example.com" <url>` |
+| `--password`             | Password to source (required when using login) | `audiobook-dl --password "secret" <url>` |
+| `--library`              | Specific library on service (sometimes required when using login) | `audiobook-dl --library dk <url>` |
+| `--skip-downloaded`      | Skip download if output file/folder already exists | `audiobook-dl --skip-downloaded <url>` |
+| `--database_directory`   | Directory for source database/cache | `audiobook-dl --database_directory "C:\audiobook-db" <url>` |
+| `--write-json-metadata`  | Write metadata in a separate `.json` file | `audiobook-dl --write-json-metadata <url>` |
+| `--config`               | Alternative location of config file | `audiobook-dl --config "C:\path\audiobook-dl.toml" <url>` |
 
 ## Output
 By default, audiobook-dl saves all audiobooks to `{title}` relative to the
@@ -98,12 +106,29 @@ current path. This can be changed with the `--output` argument. Path can be
 customized by audiobook with the following fields:
 - `title`
 - `author`
-- `series`
 - `narrator`
+- `genre`
+- `series`
+- `series_order`
+- `publisher`
+- `release_date`
+- `language`
+- `isbn`
+- `description`
+- `scrape_url`
+- `album` (default: `NA`)
+- `artist` (default: `NA`)
 
 Not all fields are available for all audiobooks.
 
 The file extension can be changed with the `--output-format` argument.
+
+### Output examples
+```shell
+audiobook-dl -o "{title}" <url>
+audiobook-dl -o "C:\Audiobooks\{author}\{title}" <url>
+audiobook-dl -o "C:\Audiobooks\{series}\{series_order} - {title}" <url>
+```
 
 ## Configuration
 audiobook-dl can be configured using a configuration file, which should be placed at:

--- a/audiobookdl/output/metadata/ffmpeg.py
+++ b/audiobookdl/output/metadata/ffmpeg.py
@@ -2,10 +2,8 @@ from audiobookdl import Chapter, utils, logging
 from mutagen import File as MutagenFile
 import subprocess
 import os
+import tempfile
 from typing import Sequence
-
-TMP_CHAPTER_FILE = "chapters.tmp.txt"
-TMP_MEDIA_FILE = "audiobook.tmp.mp4"
 
 def create_chapter_text(title: str, start: int, end: int) -> str:
     chapter_template = utils.read_asset_file("assets/ffmpeg_chapter_template.txt")
@@ -16,37 +14,75 @@ def create_chapter_text(title: str, start: int, end: int) -> str:
     )
 
 
+def _normalize_chapters(chapters: Sequence[Chapter]) -> Sequence[Chapter]:
+    normalized = []
+    seen = set()
+    for chapter in sorted(chapters, key=lambda c: int(c.start)):
+        start = int(chapter.start)
+        if start in seen:
+            continue
+        seen.add(start)
+        normalized.append(Chapter(start=start, title=chapter.title))
+    return normalized
+
+
 def create_tmp_chapter_file(filepath: str, chapters: Sequence[Chapter]) -> str:
     result = ";FFMETADATA1\n"
+    chapters = _normalize_chapters(chapters)
+    if not chapters:
+        return result
     for i in range(len(chapters)-1):
         chapter = chapters[i]
-        result += create_chapter_text(chapter.title, chapter.start, chapters[i+1].start)
+        next_start = chapters[i+1].start
+        if next_start <= chapter.start:
+            continue
+        result += create_chapter_text(chapter.title, chapter.start, next_start)
     length = MutagenFile(filepath).info.length*1000
     last_chapter = chapters[-1]
+    end = max(last_chapter.start + 1, int(length))
     result += create_chapter_text(
         title = last_chapter.title,
         start = last_chapter.start,
-        end = int(length)
+        end = end
     )
     return result
 
 def add_chapters_ffmpeg(filepath: str, chapters: Sequence[Chapter]):
+    tmp_chapter_file = None
+    tmp_media_file = None
     try:
-        with open(TMP_CHAPTER_FILE, "w") as f:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            suffix=".ffmeta",
+            delete=False
+        ) as f:
+            tmp_chapter_file = f.name
             f.write(create_tmp_chapter_file(filepath, chapters))
+
+        _, output_ext = os.path.splitext(filepath)
+        with tempfile.NamedTemporaryFile(
+            suffix=output_ext or ".tmp",
+            delete=False
+        ) as f:
+            tmp_media_file = f.name
+
         subprocess.run(
             ["ffmpeg", "-y", 
              "-i", filepath, 
-             "-i", TMP_CHAPTER_FILE,
+             "-f", "ffmetadata",
+             "-i", tmp_chapter_file,
              "-map_chapters", "1",
              "-c", "copy",
              "-map", "0",
-             "-metadata:s:a:0", "title=",
-             TMP_MEDIA_FILE],
-            capture_output = not logging.ffmpeg_output
+              "-metadata:s:a:0", "title=",
+             tmp_media_file],
+            capture_output = not logging.ffmpeg_output,
+            check=True
         )
-        os.remove(filepath)
-        os.rename(TMP_MEDIA_FILE, filepath)
+        os.replace(tmp_media_file, filepath)
     finally:
-        os.remove(TMP_CHAPTER_FILE)
+        if tmp_chapter_file and os.path.exists(tmp_chapter_file):
+            os.remove(tmp_chapter_file)
+        if tmp_media_file and os.path.exists(tmp_media_file):
+            os.remove(tmp_media_file)
         

--- a/audiobookdl/output/output.py
+++ b/audiobookdl/output/output.py
@@ -12,7 +12,7 @@ LOCATION_DEFAULTS = {
     'artist': 'NA',
 }
 
-COMBINE_CHUNK_SIZE = 500
+COMBINE_CHUNK_SIZE = 100
 
 def gen_output_filename(booktitle: str, file: Mapping[str, str], template: str) -> str:
     """Generates an output filename based on different attributes of the

--- a/audiobookdl/sources/nextory.py
+++ b/audiobookdl/sources/nextory.py
@@ -188,7 +188,7 @@ class NextorySource(Source):
             # TODO Handle redirect correctly
             media_url = file["uri"].replace("master", "media")
             files.extend(
-                self.get_stream_files(media_url, headers=self._session.headers)
+                self.get_stream_files(media_url, headers=self._session.headers, extension="aac")
             )
         return files
 
@@ -203,11 +203,18 @@ class NextorySource(Source):
 
 
     def get_chapters(self, audio_data: dict) -> List[Chapter]:
+        # Some books contain duplicate or out-of-order start offsets.
+        # Normalize starts so chapter metadata stays valid for ffmpeg.
+        starts = []
+        for file in audio_data["files"]:
+            try:
+                starts.append(int(file["start_at"]))
+            except (TypeError, ValueError):
+                continue
+        starts = sorted(set(starts))
         chapters = []
-        for index, file in enumerate(audio_data["files"]):
-            chapters.append(
-                Chapter(title = f"Chapter {index+1}", start = file["start_at"])
-            )
+        for index, start in enumerate(starts):
+            chapters.append(Chapter(title=f"Chapter {index+1}", start=start))
         return chapters
 
 


### PR DESCRIPTION
PSA - This is first time trying to do something in Github. I identified the issue and asked AI to help fix it. I'm not super experienced developer so take this fix with the usual AI slob caution. It did solve the issue for me.

Issue was that ffmpeg did try to execute a command that was way to long for Windows when trying to --combine from Nextory with 5.000+ .aac files. Solution was to change COMBINE_CHUNK_SIZE = 500 > COMBINE_CHUNK_SIZE = 100 in output.py

Afterwards there was some issues with chapters. So --no-chapters did succeed, but would rather have a way that tries to add chapters if possible and then if it fails instead of crash it just doesn't do it.

Summary:

Reduce COMBINE_CHUNK_SIZE from 500 to 100 to improve stability on large Nextory books.
Normalize Nextory chapter start times (sorted, deduplicated, numeric) to avoid invalid chapter ranges.
Harden ffmpeg chapter embedding: valid chapter ranges only, temp-file handling, check=True, and safe replace to avoid losing output on failure.
