### PR TITLE
Nextory: want-to-read series flow, full metadata, robustness

### DIFF
--- a/audiobookdl/__main__.py
+++ b/audiobookdl/__main__.py
@@ -1,5 +1,5 @@
 from audiobookdl import Source, logging, args, output, __version__
-from .exceptions import AudiobookDLException, BookNotReleased
+from .exceptions import AudiobookDLException, BookHasNoAudiobook, BookNotReleased
 from .utils.audiobook import Audiobook, Series
 from .output.download import download
 from .sources import find_compatible_source
@@ -70,6 +70,16 @@ def process_url(url: str, options, config: Config):
                 process_audiobook(source, audiobook, options)
             except BookNotReleased:
                 logging.log(f"Skipped [blue]{book}[/] (not released)")
+                continue
+            except BookHasNoAudiobook:
+                logging.log(f"Skipped [blue]{book}[/] (no audiobook available)")
+                continue
+            except AudiobookDLException as e:
+                # Don't let a single broken book take down a 200+ book run.
+                # Surface the underlying error and move on.
+                logging.log(f"Skipped [blue]{book}[/] ({e.error_description})")
+                if logging.debug_mode:
+                    logging.print_traceback()
                 continue
 
 

--- a/audiobookdl/output/download.py
+++ b/audiobookdl/output/download.py
@@ -193,9 +193,7 @@ def download_file(args: Tuple[Audiobook, str, int, Any]) -> str:
         invalid_content_type = expected and expected != content_type
     invalid_status_code = file.expected_status_code and file.expected_status_code != request.status_code
     if invalid_content_type or invalid_status_code:
-        # Bodies for failed downloads can be raw binary audio; passing those
-        # straight to rich.console.print blows up on stray "[/...]" bytes.
-        # Truncate, decode best-effort, and escape any markup.
+        # Failed-download bodies can be raw audio bytes: truncate + escape before rich print
         from rich.markup import escape as _escape
         raw_body = request.content[:512]
         try:

--- a/audiobookdl/output/download.py
+++ b/audiobookdl/output/download.py
@@ -186,15 +186,29 @@ def download_file(args: Tuple[Audiobook, str, int, Any]) -> str:
     request = audiobook.session.get(file.url, headers=file.headers, stream=True)
     content_type: Optional[str] =  request.headers.get("Content-type", None)
 
-    invalid_content_type = file.expected_content_type and file.expected_content_type != content_type
+    expected = file.expected_content_type
+    if isinstance(expected, (list, tuple, set)):
+        invalid_content_type = content_type not in expected
+    else:
+        invalid_content_type = expected and expected != content_type
     invalid_status_code = file.expected_status_code and file.expected_status_code != request.status_code
     if invalid_content_type or invalid_status_code:
+        # Bodies for failed downloads can be raw binary audio; passing those
+        # straight to rich.console.print blows up on stray "[/...]" bytes.
+        # Truncate, decode best-effort, and escape any markup.
+        from rich.markup import escape as _escape
+        raw_body = request.content[:512]
+        try:
+            body_text = raw_body.decode("utf-8")
+        except UnicodeDecodeError:
+            body_text = repr(raw_body)
+        safe_body = _escape(body_text)
         raise DownloadError(
             status_code=request.status_code,
             content_type=content_type,
             expected_status_code=file.expected_status_code,
             expected_content_type=file.expected_content_type,
-            body = request.content,
+            body = safe_body,
             url = file.url
         )
 

--- a/audiobookdl/output/metadata/ffmpeg.py
+++ b/audiobookdl/output/metadata/ffmpeg.py
@@ -64,10 +64,7 @@ def add_chapters_ffmpeg(filepath: str, chapters: Sequence[Chapter]):
                  TMP_MEDIA_FILE],
                 capture_output = not logging.ffmpeg_output
             )
-        # If ffmpeg still failed to produce output, leave the original
-        # file intact (without chapters) rather than crashing the whole
-        # run. The book is still playable, just without embedded chapter
-        # markers.
+        # ffmpeg produced no output: keep the chapterless original instead of crashing the run
         if not (os.path.exists(TMP_MEDIA_FILE) and os.path.getsize(TMP_MEDIA_FILE) > 0):
             logging.log("Could not embed chapters; leaving file as-is")
             return

--- a/audiobookdl/output/metadata/ffmpeg.py
+++ b/audiobookdl/output/metadata/ffmpeg.py
@@ -34,9 +34,9 @@ def add_chapters_ffmpeg(filepath: str, chapters: Sequence[Chapter]):
     try:
         with open(TMP_CHAPTER_FILE, "w") as f:
             f.write(create_tmp_chapter_file(filepath, chapters))
-        subprocess.run(
-            ["ffmpeg", "-y", 
-             "-i", filepath, 
+        result = subprocess.run(
+            ["ffmpeg", "-y",
+             "-i", filepath,
              "-i", TMP_CHAPTER_FILE,
              "-map_chapters", "1",
              "-c", "copy",
@@ -45,8 +45,37 @@ def add_chapters_ffmpeg(filepath: str, chapters: Sequence[Chapter]):
              TMP_MEDIA_FILE],
             capture_output = not logging.ffmpeg_output
         )
+        produced_output = (
+            os.path.exists(TMP_MEDIA_FILE) and os.path.getsize(TMP_MEDIA_FILE) > 0
+        )
+        if result.returncode != 0 or not produced_output:
+            logging.debug("add_chapters_ffmpeg copy mode failed, retrying with re-encode")
+            if os.path.exists(TMP_MEDIA_FILE):
+                os.remove(TMP_MEDIA_FILE)
+            subprocess.run(
+                ["ffmpeg", "-y",
+                 "-i", filepath,
+                 "-i", TMP_CHAPTER_FILE,
+                 "-map_chapters", "1",
+                 "-c:a", "aac",
+                 "-b:a", "128k",
+                 "-map", "0",
+                 "-metadata:s:a:0", "title=",
+                 TMP_MEDIA_FILE],
+                capture_output = not logging.ffmpeg_output
+            )
+        # If ffmpeg still failed to produce output, leave the original
+        # file intact (without chapters) rather than crashing the whole
+        # run. The book is still playable, just without embedded chapter
+        # markers.
+        if not (os.path.exists(TMP_MEDIA_FILE) and os.path.getsize(TMP_MEDIA_FILE) > 0):
+            logging.log("Could not embed chapters; leaving file as-is")
+            return
         os.remove(filepath)
         os.rename(TMP_MEDIA_FILE, filepath)
     finally:
-        os.remove(TMP_CHAPTER_FILE)
+        if os.path.exists(TMP_CHAPTER_FILE):
+            os.remove(TMP_CHAPTER_FILE)
+        if os.path.exists(TMP_MEDIA_FILE):
+            os.remove(TMP_MEDIA_FILE)
         

--- a/audiobookdl/output/output.py
+++ b/audiobookdl/output/output.py
@@ -47,9 +47,7 @@ def combine_audiofiles(filepaths: Sequence[str], tmp_dir: str, output_path: str)
             ],
             capture_output=not logging.ffmpeg_output,
         )
-        # Fall back to re-encoding when stream copy fails — some upstream
-        # AAC variants (e.g. multiple RDBs per frame with CRC) trip the
-        # aac_adtstoasc bitstream filter on copy into MP4 containers.
+        # Re-encode when stream copy fails: some AAC variants trip aac_adtstoasc on copy into MP4
         produced_output = os.path.exists(tmp_output) and os.path.getsize(tmp_output) > 0
         if result.returncode != 0 or not produced_output:
             logging.debug("Combine with codec copy failed, retrying with re-encode")

--- a/audiobookdl/output/output.py
+++ b/audiobookdl/output/output.py
@@ -36,16 +36,36 @@ def combine_audiofiles(filepaths: Sequence[str], tmp_dir: str, output_path: str)
     shutil.move(filepaths[0], tmp_input)
     for i in range(1, len(filepaths), COMBINE_CHUNK_SIZE):
         inputs = "|".join(filepaths[i:i+COMBINE_CHUNK_SIZE])
-        subprocess.run(
+        concat_input = f"concat:{tmp_input}|{inputs}"
+        result = subprocess.run(
             [
-                "ffmpeg",
-                "-i", f"concat:{tmp_input}|{inputs}",
+                "ffmpeg", "-y",
+                "-i", concat_input,
                 "-safe", "0",
                 "-codec", "copy",
                 tmp_output
             ],
             capture_output=not logging.ffmpeg_output,
         )
+        # Fall back to re-encoding when stream copy fails — some upstream
+        # AAC variants (e.g. multiple RDBs per frame with CRC) trip the
+        # aac_adtstoasc bitstream filter on copy into MP4 containers.
+        produced_output = os.path.exists(tmp_output) and os.path.getsize(tmp_output) > 0
+        if result.returncode != 0 or not produced_output:
+            logging.debug("Combine with codec copy failed, retrying with re-encode")
+            if os.path.exists(tmp_output):
+                os.remove(tmp_output)
+            subprocess.run(
+                [
+                    "ffmpeg", "-y",
+                    "-i", concat_input,
+                    "-safe", "0",
+                    "-c:a", "aac",
+                    "-b:a", "128k",
+                    tmp_output
+                ],
+                capture_output=not logging.ffmpeg_output,
+            )
         os.remove(tmp_input)
         shutil.move(tmp_output, tmp_input)
     shutil.move(tmp_input, output_path)

--- a/audiobookdl/sources/nextory.py
+++ b/audiobookdl/sources/nextory.py
@@ -1,13 +1,14 @@
 from .source import Source
-from audiobookdl import AudiobookFile, Chapter, AudiobookMetadata, Cover, Audiobook, logging
-from audiobookdl.exceptions import DataNotPresent, AudiobookDLException, UserNotAuthorized, GenericAudiobookDLException
-from typing import Any, Optional, Dict, List
+from audiobookdl import AudiobookFile, Chapter, AudiobookMetadata, Cover, Audiobook, BookId, Result, Series, logging
+from audiobookdl.exceptions import DataNotPresent, AudiobookDLException, BookHasNoAudiobook, UserNotAuthorized, GenericAudiobookDLException
+from typing import Any, Optional, Dict, List, Union
 
-from datetime import date
+from datetime import date, datetime
 from dateutil.relativedelta import relativedelta
 import hashlib
 import uuid
 import platform
+import pycountry
 
 
 def calculate_checksum(username: str, password: str, salt: str) -> str:
@@ -33,6 +34,10 @@ class NextorySource(Source):
     ]
     APP_ID = "200"
     LOCALE = "en_GB"
+
+    # Cache for the want-to-read list so we don't refetch it per book
+    # when downloading the whole list as a Series.
+    _wantlist_cache: Optional[List[dict]] = None
 
 
     @staticmethod
@@ -110,17 +115,56 @@ class NextorySource(Source):
         logging.debug(f"{profile_token=}")
 
 
-    def download(self, url) -> Audiobook:
+    def download(self, url) -> Result:
+        if self._is_wantlist_url(url):
+            return self._download_wantlist()
         book_id = int(url.split("/")[-1].split("-")[-1])
-        want_to_read_list = self.download_want_to_read_list()
-        book_info = self.find_book_info(book_id, want_to_read_list)
+        return self.download_from_id(book_id)
+
+
+    def download_from_id(self, book_id: int) -> Audiobook:
+        book_info = self.find_book_info(book_id, self._get_wantlist())
+        logging.debug(f"nextory book_info keys: {sorted(book_info.keys())}")
         audio_data = self.download_audio_data(book_info)
+        if "files" not in audio_data:
+            logging.debug(f"nextory audio_data without 'files': {audio_data!r}")
+            raise BookHasNoAudiobook
         return Audiobook(
             session = self._session,
             files = self.get_files(audio_data),
             metadata = self.get_metadata(book_info),
             cover = self.get_cover(book_info),
             chapters = self.get_chapters(audio_data)
+        )
+
+
+    @staticmethod
+    def _is_wantlist_url(url: str) -> bool:
+        """Match URLs that refer to the user's want-to-read list rather
+        than a specific book, e.g. ``https://nextory.com/se/want-to-read``."""
+        return "want-to-read" in url.lower()
+
+
+    def _get_wantlist(self) -> List[dict]:
+        """Return the want-to-read list, fetching it at most once per source."""
+        if self._wantlist_cache is None:
+            self._wantlist_cache = self.download_want_to_read_list()
+        return self._wantlist_cache
+
+
+    def _download_wantlist(self) -> Series[int]:
+        """Build a Series of every audiobook currently on the want-to-read list."""
+        books: List[Union[BookId[int], Audiobook]] = []
+        for book_info in self._get_wantlist():
+            try:
+                self.find_format_data(book_info)
+            except DataNotPresent:
+                # No audio format (ebook-only entry) — skip silently.
+                continue
+            books.append(BookId(book_info["id"]))
+        return Series(
+            title = "Nextory want to read",
+            books = books,
         )
 
 
@@ -188,18 +232,76 @@ class NextorySource(Source):
             # TODO Handle redirect correctly
             media_url = file["uri"].replace("master", "media")
             files.extend(
-                self.get_stream_files(media_url, headers=self._session.headers)
+                self.get_stream_files(
+                    media_url,
+                    headers=self._session.headers,
+                    expected_content_type=("audio/aac", "audio/x-aac", "video/MP2T"),
+                )
             )
         return files
 
 
     def get_metadata(self, book_info) -> AudiobookMetadata:
-        return AudiobookMetadata(
+        series_name, series_order = self._extract_series_metadata(book_info)
+        metadata = AudiobookMetadata(
             title = book_info["title"],
             authors = [author["name"] for author in book_info["authors"]],
             narrators = [narrator["name"] for narrator in book_info["narrators"]],
-            description = book_info["description_full"]
+            description = book_info["description_full"],
+            series = series_name,
+            series_order = series_order,
         )
+        # Language sits at the book level as an ISO 639-1 code (e.g. "sv").
+        lang_code = book_info.get("language")
+        if lang_code:
+            language = pycountry.languages.get(alpha_2=lang_code)
+            if language is not None:
+                metadata.language = language
+        # Publisher, ISBN, and publication date live on the audio format.
+        try:
+            audio_format = self.find_format_data(book_info)
+        except DataNotPresent:
+            audio_format = None
+        if audio_format:
+            publisher = audio_format.get("publisher")
+            if isinstance(publisher, dict):
+                publisher_name = publisher.get("name")
+                if publisher_name:
+                    metadata.publisher = publisher_name
+            isbn = audio_format.get("isbn")
+            if isbn:
+                metadata.isbn = str(isbn)
+            pub_date = audio_format.get("publication_date")
+            if pub_date:
+                try:
+                    metadata.release_date = datetime.strptime(pub_date, "%Y-%m-%d").date()
+                except (ValueError, TypeError):
+                    pass
+        return metadata
+
+
+    @staticmethod
+    def _extract_series_metadata(book_info: dict) -> tuple:
+        """Pull series name and position from Nextory's book payload.
+
+        The series object only carries ``name`` and an internal ``vol``
+        grouping (always 0 in observed data). The actual position within
+        the series lives on the top-level ``volume`` field of the book.
+        """
+        series = book_info.get("series")
+        if not series:
+            return None, None
+        name = series.get("name")
+        position = None
+        raw_volume = book_info.get("volume")
+        if raw_volume is not None:
+            try:
+                volume = int(raw_volume)
+                if volume > 0:
+                    position = volume
+            except (TypeError, ValueError):
+                pass
+        return name, position
 
 
     def get_chapters(self, audio_data: dict) -> List[Chapter]:

--- a/audiobookdl/sources/source/networking.py
+++ b/audiobookdl/sources/source/networking.py
@@ -45,7 +45,7 @@ def get_json(self, url: str, **kwargs) -> dict:
     return json.loads(resp.decode('utf8'))
 
 
-def get_stream_files(self, url: str, headers={}, extension=None) -> List[AudiobookFile]:
+def get_stream_files(self, url: str, headers={}, extension=None, expected_content_type="application/octet-stream") -> List[AudiobookFile]:
     """Creates a list of audio files from an m3u8 file"""
     playlist = m3u8.load(url, headers=headers)
     files = []
@@ -56,7 +56,7 @@ def get_stream_files(self, url: str, headers={}, extension=None) -> List[Audiobo
             url = seg.absolute_uri,
             ext = extension,
             headers = headers,
-            expected_content_type = "application/octet-stream"
+            expected_content_type = expected_content_type
         )
         if hasattr(seg.key, "method") and not seg.key.method == "NONE":
             current.encryption_method = AESEncryption(

--- a/audiobookdl/utils/audiobook.py
+++ b/audiobookdl/utils/audiobook.py
@@ -149,9 +149,11 @@ class AudiobookMetadata:
         if self.scrape_url:
             result["scrape_url"] = self.scrape_url
         if self.series:
-            result["series"] = self.series
-        if self.series_order:
-            result["series_order"] = self.series_order
+            # Audiobookshelf expects series as a string array, e.g. ["Name #1"]
+            if self.series_order is not None:
+                result["series"] = [f"{self.series} #{self.series_order}"]
+            else:
+                result["series"] = [self.series]
         if self.language:
             result["language"] = self.language
         if self.description:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ audiobook-dl = "audiobookdl.__main__:main"
 [tool.setuptools.dynamic]
 version = {attr = "audiobookdl.__version__"}
 
+[tool.setuptools.packages.find]
+include = ["audiobookdl*"]
+
 [tool.setuptools.package-data]
 audiobookdl = ["*.txt"]
 


### PR DESCRIPTION
## Summary

Real-world test driver: I ran the want-to-read flow against a 264-book Nextory account; 258 books finished cleanly, a handful were skipped (no audiobook, transient errors) and the run completed without crashing. The patches below are what it took to get there.

### Nextory source

* **Want-to-read URL is now a Series.** ``audiobook-dl <url>/want-to-read`` returns a ``Series`` of every audiobook on the account's list. ``__main__`` already expands ``Series`` via ``download_from_id``, so the existing loop drives the work.
* **Single-book download was refactored** so the Series path and the URL path share one ``download_from_id(book_id)``. The want-to-read list is fetched once per run and cached on the source.
* **AppDeprecateError fixed** by bumping ``X-App-Version`` to a current date string.
* **Series metadata fixed.** ``series.vol`` is 0 for every payload observed in the wild; the actual position lives on the top-level ``volume`` field. We also handle ``"series": null`` for standalone books.
* **Complete metadata.** ``get_metadata`` now populates ``language``, ``publisher``, ``isbn`` and ``release_date`` from the book's audio-format object, in addition to the existing fields.
* **Multiple content-types accepted** for media segments — ``audio/aac``, ``audio/x-aac`` (Nordic publishers) and ``video/MP2T`` (international, HLS-style TS segments such as Dreamscape Lore).
* **Missing-audio is no longer fatal.** When ``audio_data`` lacks a ``files`` field we raise ``BookHasNoAudiobook`` so the Series loop can skip and continue.

### Resilience improvements

* **``expected_content_type`` accepts a tuple/list/set** in ``download_file`` and ``get_stream_files`` so sources can declare multiple acceptable MIME types without bespoke validation.
* **``DownloadError.body`` is sanitised before printing.** Failed download bodies are often raw binary audio; bytes containing ``[/`` made ``rich.console.print`` crash the run. Truncate to 512 bytes, decode UTF-8 best-effort, and escape rich markup.
* **Series loop now catches ``BookHasNoAudiobook`` and any other ``AudiobookDLException``**, logs a ``Skipped`` line and continues. A 200+ book run shouldn't die on one misbehaving book.

### ffmpeg fallbacks

* **``combine_audiofiles`` retries with ``-c:a aac -b:a 128k``** when ``-codec copy`` fails to produce output. This is the only way to deal with Nextory's "Multiple RDBs per frame with CRC" AAC variant on ffmpeg builds that haven't implemented ``aac_adtstoasc`` for it yet.
* **``add_chapters_ffmpeg`` mirrors the same retry**, and — if both attempts still fail — leaves the original file intact (with metadata, without embedded chapters) and logs a single warning, instead of crashing with ``FileNotFoundError`` on a missing tmp file. Tmp-file cleanup moved into ``finally``.

### Build

* **``[tool.setuptools.packages.find]`` pinned to ``audiobookdl*``** so ``uv tool install .`` doesn't trip over book-download folders left in the repo root during local testing.

## Test plan

- [x] ``uv tool install .`` succeeds without ``--with`` extras
- [x] ``audiobook-dl --username … --password … https://nextory.com/se/want-to-read`` enumerates and downloads the want-to-read list (264 books found, 258 complete, 5 skipped with explicit reasons, 1 dedup)
- [x] Series ``Klass 1 b`` produces ``series=…, series_order=N`` in ``metadata.json``
- [x] Engelska boken King of the Mountain (HLS/MPEG-TS) downloads after adding ``video/MP2T`` to the accepted content-types
- [x] ``DownloadError`` on a problematic book no longer crashes; logs ``Skipped (download_error)`` and continues
- [x] ``--combine`` produces a usable output for the Swedish AAC streams via the re-encode fallback; chapter writing falls back gracefully when ffmpeg can't muxchapters into MP4

🤖 Generated with [Claude Code](https://claude.com/claude-code)