### PR TITLE
Add release_date output field to Podimo

### DIFF
--- a/audiobookdl/sources/podimo.py
+++ b/audiobookdl/sources/podimo.py
@@ -6,6 +6,7 @@ from audiobookdl.utils.audiobook import Audiobook, AudiobookFile, AudiobookMetad
 from audiobookdl.utils import http
 
 import re
+from datetime import datetime
 from typing import List
 import requests
 from requests import Response
@@ -198,6 +199,12 @@ class PodimoSource(Source[dict]):
             series = episode_info.get("podcastName"),
             description = episode_info.get("description"),
         )
+        pub = episode_info.get("publishDatetime")
+        if pub:
+            # Podimo returns ISO 8601, sometimes with a trailing Z
+            metadata.release_date = datetime.fromisoformat(
+                pub.replace("Z", "+00:00")
+            ).date()
         if episode_info["authorName"]:
             metadata.add_author(episode_info["authorName"])
         return metadata


### PR DESCRIPTION
This adds the `{release_date}` output field to Podimo episodes.

Example

```sh
❯ uv run audiobook-dl https://open.podimo.com/podcast/820ba2ad-f1b4-459d-b42f-9abe4637aaf0 -o "{series}/{release_date} - {title}" --config config.toml
warning: No `requires-python` value found in the workspace. Defaulting to `>=3.13`.
Finding compatible source
Authenticating with podimo

Downloading 100 books in Berrum & Beyer snakker om greier from podimo
  Downloading Trailer ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100%
  Adding metadata
  Embedding cover
  Downloading Omega 3-egg, Danish Tech og Bagorama ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100%
  Adding metadata
  Embedding cover
  Downloading Jon Almaas: Fettpumpe og svære dekk ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100%
  Adding metadata
  Embedding cover
[...]
```

Result

```sh
❯ ls Berrum\ \&\ Beyer\ snakker\ om\ greier/
'2025-01-30 - Trailer.mp3'
'2025-02-04 - Omega 3-egg, Danish Tech og Bagorama.mp3'
'2025-02-07 - Jon Almaas: Fettpumpe og svære dekk.mp3'
[...]
```